### PR TITLE
WIP: Update configuration for Plone 5.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,14 @@ on:
       - "main"
       - "master"
       - "features/buildout-tox"
+      - "features/plone52"
       - "!releases/**"
   pull_request:
     branches:
       - "main"
       - "master"
       - "features/buildout-tox"
+      - "features/plone52"
 
 jobs:
   ci:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,9 @@ Changelog
 - Use tox for testing, ensure tests are passing for Plone 5.0.x, 5.1.x and 5.2.x.
   [thomasmassmann]
 
+- Adjust configlet URLs to use navigation root url. This is required for Plone 5.2.x and is backward compatible.
+  [thomasmassmann]
+
 
 1.0a1 (2016-10-06)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -34,22 +34,26 @@ Not available in Lineage Childsites
 
 The following control panels change global settings. Therefore they are not available in subsites.
 
+- actions-controlpanel (Plone 5.1 and newer)
 - content-controlpanel
 - dexterity-types
 - filter-controlpanel
 - maintenance-controlpanel
 - prefs_install_products_form
+- redirection-controlpanel (Plone 5.2 and newer)
 - resourceregistry-controlpanel
-- security controlpanel
+- security-controlpanel
 - usergroup-groupprefs
 - usergroup-userprefs
 
 
 This is also disabled, but should probably fixed to work with local registries too:
+
 - portal_registry
 
 This one stores it's configuration in the registry but has changes one setting in portal_actions, which would affect all sites.
 Thus disabled.
+
 - syndication-controlpanel
 
 

--- a/base.cfg
+++ b/base.cfg
@@ -26,6 +26,8 @@ auto-checkout = *
 
 [sources]
 collective.lineage = git https://github.com/collective/collective.lineage.git
+# Required until https://github.com/plone/Products.CMFPlone/issues/3288 is fixed.
+cusy.patches.cmfplone = git https://github.com/cusyio/cusy.patches.cmfplone.git
 lineage.themeselection = git https://github.com/collective/lineage.themeselection.git
 
 
@@ -39,6 +41,8 @@ eggs =
     Plone
     Pillow
     lineage.controlpanels [test]
+# Required until https://github.com/plone/Products.CMFPlone/issues/3288 is fixed.
+    cusy.patches.cmfplone
 
 [vscode]
 recipe = collective.recipe.vscode

--- a/src/lineage/controlpanels/configure.zcml
+++ b/src/lineage/controlpanels/configure.zcml
@@ -1,7 +1,8 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
+    xmlns:browser="http://namespaces.zope.org/browser"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
-    xmlns:browser="http://namespaces.zope.org/browser">
+    xmlns:zcml="http://namespaces.zope.org/zcml">
 
   <!-- needed for control panel permission -->
   <include package="Products.CMFPlone.controlpanel" />
@@ -140,13 +141,42 @@
       directory="profiles/default"
       description="Extension lineage.controlpanels to allow child-site specific configurations with Plone controlpanels."
       provides="Products.GenericSetup.interfaces.EXTENSION"
+      post_handler=".setuphandlers.post_install"
       />
+
+  <genericsetup:registerProfile
+      name="plone51"
+      title="Lineage: Plone Controlpanels in Child Sites for Plone 5.1 and newer."
+      directory="profiles/plone51"
+      description="Extension lineage.controlpanels to allow child-site specific configurations with Plone controlpanels."
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      zcml:condition="have plone-51"
+      />
+
+  <genericsetup:registerProfile
+      name="plone52"
+      title="Lineage: Plone Controlpanels in Child Sites for Plone 5.2 and newer."
+      directory="profiles/plone52"
+      description="Extension lineage.controlpanels to allow child-site specific configurations with Plone controlpanels."
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      zcml:condition="have plone-52"
+      />
+
   <genericsetup:registerProfile
       name="uninstall"
       title="Lineage: Plone Controlpanels in Child Sites (uninstall)"
       directory="profiles/uninstall"
       description="Uninstalls the lineage.controlpanels add-on."
       provides="Products.GenericSetup.interfaces.EXTENSION"
+      />
+
+  <utility
+      factory=".setuphandlers.HiddenProfiles"
+      name="lineage.controlpanels-hiddenprofiles"
+      />
+
+  <subscriber
+      handler=".setuphandlers.handle_profile_imported_event"
       />
 
 </configure>

--- a/src/lineage/controlpanels/profiles/default/controlpanel.xml
+++ b/src/lineage/controlpanels/profiles/default/controlpanel.xml
@@ -57,12 +57,7 @@
     i18n:attributes="title">
   <permission>Plone Site Setup: Mail</permission>
  </configlet>
- <configlet title="Themes" action_id="PortalSkin" appId="PortalSkin"
-    category="plone-general" condition_expr="not:python:plone_portal_state.navigation_root().restrictedTraverse('@@lineageutils').isChildSite()"
-    icon_expr="string:$portal_url/skins_icon.png"
-    url_expr="string:${portal_url}/@@skins-controlpanel" visible="True"
-    i18n:attributes="title">
-  <permission>Plone Site Setup: Themes</permission>
+ <configlet title="Themes" action_id="PortalSkin" appId="PortalSkin" remove="True">
  </configlet>
  <configlet title="Editing" action_id="EditingSettings" appId="Plone"
     category="plone-content" condition_expr=""

--- a/src/lineage/controlpanels/profiles/default/controlpanel.xml
+++ b/src/lineage/controlpanels/profiles/default/controlpanel.xml
@@ -2,7 +2,7 @@
 <object name="portal_controlpanel" meta_type="Plone Control Panel Tool"
   i18n:domain="plone" xmlns:i18n="http://xml.zope.org/namespaces/i18n">
  <configlet title="Add-ons" action_id="QuickInstaller" appId="QuickInstaller"
-    category="plone-general" condition_expr="not:object/aq_parent/@@lineageutils/isChildSite"
+    category="plone-general" condition_expr="not:python:plone_portal_state.navigation_root().restrictedTraverse('@@lineageutils').isChildSite()"
     icon_expr="string:$portal_url/product_icon.png"
     url_expr="string:${portal_url}/prefs_install_products_form"
     visible="True" i18n:attributes="title">
@@ -11,26 +11,26 @@
  <configlet title="Site" action_id="PloneReconfig" appId="Plone"
     category="plone-general" condition_expr=""
     icon_expr="string:$portal_url/logoIcon.png"
-    url_expr="string:${object/aq_parent/absolute_url}/@@site-controlpanel" visible="True"
+    url_expr="string:${plone_portal_state/navigation_root_url}/@@site-controlpanel" visible="True"
     i18n:attributes="title">
   <permission>Plone Site Setup: Site</permission>
  </configlet>
  <configlet title="Date and Time" action_id="DateAndTime" appId="DateAndTime"
     category="plone-general" condition_expr=""
     icon_expr="string:$portal_url/event_icon.png"
-    url_expr="string:${object/aq_parent/absolute_url}/@@dateandtime-controlpanel" visible="True"
+    url_expr="string:${plone_portal_state/navigation_root_url}/@@dateandtime-controlpanel" visible="True"
     i18n:attributes="title">
   <permission>Plone Site Setup: Site</permission>
  </configlet>
  <configlet title="Users and Groups" action_id="UsersGroups"
-    appId="UsersGroups" category="plone-users" condition_expr="not:object/aq_parent/@@lineageutils/isChildSite"
+    appId="UsersGroups" category="plone-users" condition_expr="not:python:plone_portal_state.navigation_root().restrictedTraverse('@@lineageutils').isChildSite()"
     icon_expr="string:$portal_url/group.png"
     url_expr="string:${portal_url}/@@usergroup-userprefs" visible="True"
     i18n:attributes="title">
   <permission>Plone Site Setup: Users and Groups</permission>
  </configlet>
  <configlet title="Users and Groups" action_id="UsersGroups2"
-    appId="UsersGroups" category="plone-users" condition_expr="not:object/aq_parent/@@lineageutils/isChildSite"
+    appId="UsersGroups" category="plone-users" condition_expr="not:python:plone_portal_state.navigation_root().restrictedTraverse('@@lineageutils').isChildSite()"
     icon_expr="string:$portal_url/group.png"
     url_expr="string:${portal_url}/@@usergroup-groupprefs" visible="False"
     i18n:attributes="title">
@@ -39,26 +39,26 @@
  <configlet title="Personal Preferences" action_id="MemberPrefs" appId="Plone"
     category="Member" condition_expr=""
     icon_expr="string:$portal_url/user.png"
-    url_expr="string:${object/aq_parent/absolute_url}/@@personal-preferences" visible="True"
+    url_expr="string:${plone_portal_state/navigation_root_url}/@@personal-preferences" visible="True"
     i18n:attributes="title">
   <permission>Set own properties</permission>
  </configlet>
  <configlet title="Change Password" action_id="MemberPassword" appId="Plone"
     category="Member" condition_expr="python:member.canPasswordSet()"
     icon_expr="string:$portal_url/lock_icon.png"
-    url_expr="string:${object/aq_parent/absolute_url}/password_form" visible="True"
+    url_expr="string:${plone_portal_state/navigation_root_url}/password_form" visible="True"
     i18n:attributes="title">
   <permission>Set own password</permission>
  </configlet>
  <configlet title="Mail" action_id="MailHost" appId="MailHost"
     category="plone-general" condition_expr=""
     icon_expr="string:$portal_url/mail_icon.png"
-    url_expr="string:${object/aq_parent/absolute_url}/@@mail-controlpanel" visible="True"
+    url_expr="string:${plone_portal_state/navigation_root_url}/@@mail-controlpanel" visible="True"
     i18n:attributes="title">
   <permission>Plone Site Setup: Mail</permission>
  </configlet>
  <configlet title="Themes" action_id="PortalSkin" appId="PortalSkin"
-    category="plone-general" condition_expr="not:object/aq_parent/@@lineageutils/isChildSite"
+    category="plone-general" condition_expr="not:python:plone_portal_state.navigation_root().restrictedTraverse('@@lineageutils').isChildSite()"
     icon_expr="string:$portal_url/skins_icon.png"
     url_expr="string:${portal_url}/@@skins-controlpanel" visible="True"
     i18n:attributes="title">
@@ -67,19 +67,19 @@
  <configlet title="Editing" action_id="EditingSettings" appId="Plone"
     category="plone-content" condition_expr=""
     icon_expr="string:$portal_url/cut_icon.png"
-    url_expr="string:${object/aq_parent/absolute_url}/@@editing-controlpanel" visible="True"
+    url_expr="string:${plone_portal_state/navigation_root_url}/@@editing-controlpanel" visible="True"
     i18n:attributes="title">
   <permission>Plone Site Setup: Editing</permission>
  </configlet>
  <configlet title="Errors" action_id="errorLog" appId="ErrorLog"
-    category="plone-security" condition_expr="not:object/aq_parent/@@lineageutils/isChildSite"
+    category="plone-security" condition_expr="not:python:plone_portal_state.navigation_root().restrictedTraverse('@@lineageutils').isChildSite()"
     icon_expr="string:$portal_url/error_log_icon.png"
     url_expr="string:${portal_url}/prefs_error_log_form" visible="True"
     i18n:attributes="title">
   <permission>Manage portal</permission>
  </configlet>
  <configlet title="Content Settings" action_id="TypesSettings" appId="TypesSettings"
-    category="plone-content" condition_expr="not:object/aq_parent/@@lineageutils/isChildSite"
+    category="plone-content" condition_expr="not:python:plone_portal_state.navigation_root().restrictedTraverse('@@lineageutils').isChildSite()"
     icon_expr="string:$portal_url/document_icon.png"
     url_expr="string:${portal_url}/@@content-controlpanel" visible="True"
     i18n:attributes="title">
@@ -87,19 +87,19 @@
  </configlet>
  <configlet title="Markup" action_id="MarkupSettings" appId="MarkupSettings"
     category="plone-content" condition_expr="" icon_expr="string:$portal_url/edit.png"
-    url_expr="string:${object/aq_parent/absolute_url}/@@markup-controlpanel" visible="True"
+    url_expr="string:${plone_portal_state/navigation_root_url}/@@markup-controlpanel" visible="True"
     i18n:attributes="title">
   <permission>Plone Site Setup: Markup</permission>
  </configlet>
  <configlet title="Security" action_id="SecuritySettings"
-    appId="SecuritySettings" category="plone-security" condition_expr="not:object/aq_parent/@@lineageutils/isChildSite"
+    appId="SecuritySettings" category="plone-security" condition_expr="not:python:plone_portal_state.navigation_root().restrictedTraverse('@@lineageutils').isChildSite()"
     icon_expr="string:$portal_url/lock_icon.png"
     url_expr="string:${portal_url}/@@security-controlpanel" visible="True"
     i18n:attributes="title">
   <permission>Plone Site Setup: Security</permission>
  </configlet>
  <configlet title="Management Interface" action_id="ZMI" appId="ZMI"
-    category="plone-advanced" condition_expr="not:object/aq_parent/@@lineageutils/isChildSite"
+    category="plone-advanced" condition_expr="not:python:plone_portal_state.navigation_root().restrictedTraverse('@@lineageutils').isChildSite()"
     icon_expr="string:$portal_url/zope_icon.png"
     url_expr="string:${portal_url}/manage_main" visible="True"
     i18n:attributes="title">
@@ -108,33 +108,33 @@
  <configlet title="Search" action_id="SearchSettings" appId="Plone"
     category="plone-general" condition_expr=""
     icon_expr="string:$portal_url/search_icon.png"
-    url_expr="string:${object/aq_parent/absolute_url}/@@search-controlpanel" visible="True"
+    url_expr="string:${plone_portal_state/navigation_root_url}/@@search-controlpanel" visible="True"
     i18n:attributes="title">
   <permission>Plone Site Setup: Search</permission>
  </configlet>
  <configlet title="Navigation" action_id="NavigationSettings" appId="Plone"
     category="plone-general" condition_expr=""
     icon_expr="string:$portal_url/navigation_icon.png"
-    url_expr="string:${object/aq_parent/absolute_url}/@@navigation-controlpanel" visible="True"
+    url_expr="string:${plone_portal_state/navigation_root_url}/@@navigation-controlpanel" visible="True"
     i18n:attributes="title">
   <permission>Plone Site Setup: Navigation</permission>
  </configlet>
  <configlet title="Language" action_id="LanguageSettings"
     appId="Plone" category="plone-general" condition_expr=""
     icon_expr="string:$portal_url/flag-plone.png"
-    url_expr="string:${object/aq_parent/absolute_url}/@@language-controlpanel" visible="True"
+    url_expr="string:${plone_portal_state/navigation_root_url}/@@language-controlpanel" visible="True"
     i18n:attributes="title">
   <permission>Plone Site Setup: Language</permission>
  </configlet>
  <configlet title="HTML Filtering" action_id="FilterSettings" appId="FilterSettings"
-    category="plone-security" condition_expr="not:object/aq_parent/@@lineageutils/isChildSite"
+    category="plone-security" condition_expr="not:python:plone_portal_state.navigation_root().restrictedTraverse('@@lineageutils').isChildSite()"
     icon_expr="string:$portal_url/htmlfilter_icon.png"
     url_expr="string:${portal_url}/@@filter-controlpanel" visible="True"
     i18n:attributes="title">
   <permission>Plone Site Setup: Filtering</permission>
  </configlet>
  <configlet title="Maintenance" action_id="Maintenance" appId="Plone"
-    category="plone-advanced" condition_expr="not:object/aq_parent/@@lineageutils/isChildSite"
+    category="plone-advanced" condition_expr="not:python:plone_portal_state.navigation_root().restrictedTraverse('@@lineageutils').isChildSite()"
     icon_expr="string:$portal_url/maintenance_icon.png"
     url_expr="string:${portal_url}/@@maintenance-controlpanel" visible="True"
     i18n:attributes="title">
@@ -143,12 +143,12 @@
  <configlet title="Content Rules" action_id="ContentRules" appId="Plone"
     category="plone-content" condition_expr=""
     icon_expr="string:$portal_url/contentrules_icon.png"
-    url_expr="string:${object/aq_parent/absolute_url}/@@rules-controlpanel" visible="True"
+    url_expr="string:${plone_portal_state/navigation_root_url}/@@rules-controlpanel" visible="True"
     i18n:attributes="title">
   <permission>Content rules: Manage rules</permission>
  </configlet>
  <configlet title="Resource Registries" action_id="resourceregistries" appId="Plone"
-    category="plone-advanced" condition_expr="not:object/aq_parent/@@lineageutils/isChildSite"
+    category="plone-advanced" condition_expr="not:python:plone_portal_state.navigation_root().restrictedTraverse('@@lineageutils').isChildSite()"
     icon_expr=""
     url_expr="string:${portal_url}/@@resourceregistry-controlpanel" visible="True"
     i18n:attributes="title">
@@ -157,20 +157,20 @@
  <configlet title="TinyMCE" action_id="tinymce" appId="Plone"
     category="plone-general" condition_expr=""
     icon_expr="string:$portal_url/tinymce.png"
-    url_expr="string:${object/aq_parent/absolute_url}/@@tinymce-controlpanel" visible="True"
+    url_expr="string:${plone_portal_state/navigation_root_url}/@@tinymce-controlpanel" visible="True"
     i18n:attributes="title">
   <permission>Plone Site Setup: TinyMCE</permission>
  </configlet>
  <configlet title="Social Media" action_id="socialmedia" appId="Plone"
     category="plone-general" condition_expr=""
-    url_expr="string:${object/aq_parent/absolute_url}/@@social-controlpanel" visible="True"
+    url_expr="string:${plone_portal_state/navigation_root_url}/@@social-controlpanel" visible="True"
     i18n:attributes="title">
   <permission>Plone Site Setup: Site</permission>
  </configlet>
   <configlet title="Image Handling" action_id="ImagingSettings" appId="ImagingSettings"
     category="plone-content" condition_expr=""
     icon_expr="string:$portal_url/image_icon.png"
-    url_expr="string:${object/aq_parent/absolute_url}/@@imaging-controlpanel" visible="True"
+    url_expr="string:${plone_portal_state/navigation_root_url}/@@imaging-controlpanel" visible="True"
     i18n:attributes="title">
   <permission>Plone Site Setup: Imaging</permission>
  </configlet>
@@ -183,7 +183,7 @@
       category="plone-general"
       condition_expr=""
       icon_expr="string:${portal_url}/discussionitem_icon.png"
-      url_expr="string:${object/aq_parent/absolute_url}/@@discussion-controlpanel"
+      url_expr="string:${plone_portal_state/navigation_root_url}/@@discussion-controlpanel"
       visible="True"
       i18n:attributes="title">
           <permission>Manage portal</permission>
@@ -196,7 +196,7 @@
       appId="plone.app.theming"
       category="plone-general"
       condition_expr=""
-      url_expr="string:${object/aq_parent/absolute_url}/@@theming-controlpanel"
+      url_expr="string:${plone_portal_state/navigation_root_url}/@@theming-controlpanel"
       icon_expr="string:${portal_url}/++resource++plone.app.theming.gif"
       visible="True"
       i18n:attributes="title">
@@ -208,7 +208,7 @@
       action_id="plone.app.registry"
       appId="plone.app.registry"
       category="plone-advanced"
-      condition_expr="not:object/aq_parent/@@lineageutils/isChildSite"
+      condition_expr="not:python:plone_portal_state.navigation_root().restrictedTraverse('@@lineageutils').isChildSite()"
       url_expr="string:${portal_url}/portal_registry"
       icon_expr="string:$portal_url/++resource++plone.app.registry/icon.png"
       visible="True"
@@ -221,8 +221,8 @@
       action_id="plone.app.registry-lineage"
       appId="plone.app.registry"
       category="plone-advanced"
-      condition_expr="object/aq_parent/@@lineageutils/isChildSite"
-      url_expr="string:${object/aq_parent/absolute_url}/lineage_registry"
+      condition_expr="python:plone_portal_state.navigation_root().restrictedTraverse('@@lineageutils').isChildSite()"
+      url_expr="string:${plone_portal_state/navigation_root_url}/lineage_registry"
       icon_expr="string:$portal_url/++resource++plone.app.registry/icon.png"
       visible="True"
       i18n:attributes="title">
@@ -231,7 +231,7 @@
 
  <!-- syndication controlpanel alters one portal tool attribute -->
  <configlet title="Syndication" action_id="syndication" appId="Plone"
-    category="plone-general" condition_expr="not:object/aq_parent/@@lineageutils/isChildSite"
+    category="plone-general" condition_expr="not:python:plone_portal_state.navigation_root().restrictedTraverse('@@lineageutils').isChildSite()"
     icon_expr="string:$portal_url/rss.png"
     url_expr="string:${portal_url}/@@syndication-controlpanel" visible="True"
     i18n:attributes="title">
@@ -243,7 +243,7 @@
       action_id="dexterity-types"
       appId="Plone"
       category="plone-content"
-      condition_expr="not:object/aq_parent/@@lineageutils/isChildSite"
+      condition_expr="not:python:plone_portal_state.navigation_root().restrictedTraverse('@@lineageutils').isChildSite()"
       icon_expr="string:$portal_url/document_icon.png"
       title="Dexterity Content Types"
       url_expr="string:${portal_url}/@@dexterity-types"
@@ -257,7 +257,7 @@
       action_id="plone.app.caching"
       appId="plone.app.caching"
       category="plone-advanced"
-      condition_expr="not:object/aq_parent/@@lineageutils/isChildSite"
+      condition_expr="not:python:plone_portal_state.navigation_root().restrictedTraverse('@@lineageutils').isChildSite()"
       icon_expr="string:$portal_url/++resource++plone.app.caching.gif"
       url_expr="string:${portal_url}/@@caching-controlpanel"
       visible="True"

--- a/src/lineage/controlpanels/profiles/plone51/controlpanel.xml
+++ b/src/lineage/controlpanels/profiles/plone51/controlpanel.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<object name="portal_controlpanel" meta_type="Plone Control Panel Tool"
+  i18n:domain="plone" xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+ <configlet title="URL Management" action_id="RedirectionTool"
+    icon_expr="string:$portal_url/action_icon.png"
+    appId="Plone" category="plone-general"
+    condition_expr="not:python:plone_portal_state.navigation_root().restrictedTraverse('@@lineageutils').isChildSite()"
+    url_expr="string:${portal_url}/@@redirection-controlpanel"
+    visible="True"
+    i18n:attributes="title">
+  <permission>Manage Portal Aliases</permission>
+ </configlet>
+</object>

--- a/src/lineage/controlpanels/profiles/plone51/metadata.xml
+++ b/src/lineage/controlpanels/profiles/plone51/metadata.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<metadata>
+  <version>1</version>
+  <dependencies>
+  </dependencies>
+</metadata>

--- a/src/lineage/controlpanels/profiles/plone52/controlpanel.xml
+++ b/src/lineage/controlpanels/profiles/plone52/controlpanel.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<object name="portal_controlpanel" meta_type="Plone Control Panel Tool"
+  i18n:domain="plone" xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+ <configlet title="Actions" action_id="ActionSettings" appId="Plone"
+    category="plone-general" condition_expr="not:python:plone_portal_state.navigation_root().restrictedTraverse('@@lineageutils').isChildSite()"
+    url_expr="string:${portal_url}/@@actions-controlpanel" visible="True"
+    i18n:attributes="title">
+  <permission>Manage portal</permission>
+ </configlet>
+</object>

--- a/src/lineage/controlpanels/profiles/plone52/metadata.xml
+++ b/src/lineage/controlpanels/profiles/plone52/metadata.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<metadata>
+  <version>1</version>
+  <dependencies>
+  </dependencies>
+</metadata>

--- a/src/lineage/controlpanels/setuphandlers.py
+++ b/src/lineage/controlpanels/setuphandlers.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+
+from pkg_resources import parse_version
+from Products.CMFPlone.interfaces import INonInstallable
+from Products.GenericSetup.interfaces import IProfileImportedEvent
+from zope.component import adapter
+from zope.interface import implementer
+
+import plone.api
+
+
+@implementer(INonInstallable)
+class HiddenProfiles(object):
+    def getNonInstallableProfiles(self):
+        """Hide uninstall profile from site-creation and quickinstaller."""
+        return [
+            "lineage.controlpanels:uninstall",
+            "lineage.controlpanels:plone51",
+            "lineage.controlpanels:plone52",
+        ]
+
+
+@adapter(IProfileImportedEvent)
+def handle_profile_imported_event(event):
+    # Actions control panel was added
+    if event.profile_id == "profile-plone.app.upgrade.v51:to51alpha1":
+        setup = plone.api.portal.get_tool(name="portal_setup")
+        setup.runAllImportStepsFromProfile("profile-lineage.controlpanels:plone51")
+
+    # RedirectionTool was added
+    if event.profile_id == "profile-plone.app.upgrade.v52:to52beta1":
+        setup = plone.api.portal.get_tool(name="portal_setup")
+        setup.runAllImportStepsFromProfile("profile-lineage.controlpanels:plone52")
+
+
+def post_install(context):
+    """Post install script"""
+    # Check which additional configlets need to be installed/updated.
+    current_version = parse_version(plone.api.env.plone_version())
+    setup = plone.api.portal.get_tool(name="portal_setup")
+    if current_version >= parse_version("5.1a1"):
+        setup.runAllImportStepsFromProfile("profile-lineage.controlpanels:plone51")
+    if current_version >= parse_version("5.2b1"):
+        setup.runAllImportStepsFromProfile("profile-lineage.controlpanels:plone52")
+
+
+def uninstall(context):
+    """Uninstall script"""
+    # Do something at the end of the uninstallation of this package.


### PR DESCRIPTION
Related issue: https://github.com/collective/lineage.controlpanels/issues/2

This branch currently uses a patch for CMFPlone from https://github.com/cusyio/cusy.patches.cmfplone which fixes https://github.com/plone/Products.CMFPlone/issues/3288. The dependency to this patch is only included to have a working development environment and tests. The control panels will break if the navigation root is used and the patch is missing. As long as the fix in CMFPlone is missing, this request should be a draft.